### PR TITLE
Fix unix path

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ module.exports = new Namer({
 	name({ bundle, options }) {
 
 		if (options.mode === "production") {
+			const mainEntry = bundle.getMainEntry()
+			if (!mainEntry) return null
 
 			const packageJson = fs.readFileSync(path.join(process.cwd(), 'package.json')).toString();
 			const packageInfo = JSON.parse(packageJson);

--- a/index.js
+++ b/index.js
@@ -35,9 +35,10 @@ module.exports = new Namer({
 				console.log("NAME: " + distName + '.' + bundle.type);
 				return distName + '.' + bundle.type;
 			}
-			
-			console.log("NAME: " + distPath + '\\' + distName + '.' + bundle.type);
-			return distPath + '\\' + distName + '.' + bundle.type;
+
+			let name = path.join(distPath, distName + '.' + bundle.type);
+			console.log("NAME: " + name);
+			return name;
 		}
 
 		// This namer handles all files but just in case...


### PR DESCRIPTION
#1 fixed the bug in Mac OS
used `path.join` to get file path

also fixed error in case bundle.getMainEntry() returns null (took it from another [fork](https://github.com/tadejkan/parcel-namer-preserve-structure/commit/07f1543a4478f3e015e4aa7e8ba25e55624260eb))